### PR TITLE
Remove browser entry from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   ],
   "main": "dist/pakertaja.js",
   "module": "dist/pakertaja.mjs",
-  "browser": "dist/pakertaja.iife.js",
   "types": "index.d.ts",
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
Having "browser" entry in `package.json`, that is IIFE bundled seems to
cause problems with Webpack (and possibly other such bundlers) that
expect the entry to be bundled in CommonJS format, but optimized for
browsers. Lets remove it, the IIFE version can still be used through
CDN.